### PR TITLE
no dumping of \\%contig_to_genes to the cytoband file ...

### DIFF
--- a/util/fasta_and_gtf_to_cytoband.pl
+++ b/util/fasta_and_gtf_to_cytoband.pl
@@ -14,13 +14,8 @@ my $annotations = $ARGV[1] or die $usage;
 
 main: {
 
-
     my %contig_to_genes = &parse_gtf($annotations);
     
-    print Dumper(\%contig_to_genes);
-
-    
-
     my $fasta_reader = new Fasta_reader($genome_fasta);
     
     while (my $seq_obj = $fasta_reader->next()) {


### PR DESCRIPTION
The presence of `$VAR1 = {  ... ` in the cytoBand.txt file renders it less useful, as it cannot be used in e.g. an IGV session (where it is really useful). I guess it is a left-over from the development phase.