### PR TITLE
Adding a bit more granularity to fusion key in fusion_EM_runner.pl

### DIFF
--- a/util/fusion_EM_runner.pl
+++ b/util/fusion_EM_runner.pl
@@ -35,7 +35,9 @@ main: {
         my $left_breakpoint = $tab_reader->get_row_val($row, "LeftBreakpoint");
         my $right_breakpoint = $tab_reader->get_row_val($row, "RightBreakpoint");
         
-        $fusion_name .= "::" . $left_breakpoint . "::" . $right_breakpoint;
+        my $left_gene = $tab_reader->get_row_val($row, "LeftGene");
+        my $right_gene = $tab_reader->get_row_val($row, "RightGene");
+        $fusion_name .= "::" . $left_gene . "::" . $left_breakpoint . "::" . $right_gene . "::" . $right_breakpoint;
         
         $row->{fusion_isoform_name} = $fusion_name; # save it for later...
 


### PR DESCRIPTION
We had a run through FusionInspector where a read mapped to a different ensemble ID of the same gene at the exact same breakpoint which caused a key collision and then a crash downstream. 

Here is the offending input:

[GC147_1_40.fusion_preds.coalesced.summary.zip](https://github.com/FusionInspector/FusionInspector/files/15252009/GC147_1_40.fusion_preds.coalesced.summary.zip)

Where the offending fusion annotations are here:

```
➜  for_pr cat GC147_1_40.fusion_preds.coalesced.summary | grep "SLFN12L--SKAP1-AS1"
SLFN12L--SKAP1-AS1	1	0	SLFN12L^ENSG00000286065	9246	17:35474791:-	SKAP1-AS1^ENSG00000263787	16433	17:48204253:+	INCL_NON_REF_SPLICE	YES	A00405:733:HCVLWDSX7:1:1319:28456:8594/1		0	.	0	.	2.00	2.00
SLFN12L--SKAP1-AS1	1	0	SLFN12L^ENSG00000205045	9246	17:35474791:-	SKAP1-AS1^ENSG00000263787	16433	17:48204253:+	INCL_NON_REF_SPLICE	YES	A00405:733:HCVLWDSX7:1:1262:19940:36213/1		83	A00405:733:HCVLWDSX7:2:2242:17797:10332,.....
```

with the main difference being `SLFN12L^ENSG00000286065` vs `SLFN12L^ENSG00000205045` for the left gene.

This PR disambiguates that fusion key created in `fusion_EM_runner.pl` by including the left hand and right hand gene with the ensemble IDs as part of the key.

This was run though nfcore/rnafusion with `ctat_genome_lib` specified as the genome lib.

