### PR TITLE
support empty intermediate bam input

### DIFF
--- a/util/retrieve_fusion_spanning_reads_by_accession.pl
+++ b/util/retrieve_fusion_spanning_reads_by_accession.pl
@@ -44,12 +44,16 @@ main: {
         
     }
     
-    
+    my $printed_header = 0;
     my %reads_seen;
 
     foreach my $bam_file (split(/,/, $bam_file_listing) ) {
         
         my $sam_reader = new SAM_reader($bam_file);
+        if (! -s $bam_file and ! $printed_header) {
+            print "\@HD\tVN:1.6\tSO:unknown\n";
+            $printed_header = 1;
+        }
         while (my $sam_entry = $sam_reader->get_next()) {
             my $scaffold = $sam_entry->get_scaffold_name();
             


### PR DESCRIPTION
When we run the script `retrieve_fusion_spanning_reads_by_accession.pl` , if the input file `finspector.star.cSorted.dupsMarked.bam.fusion_span_reads.sam` is empty, the outpout will also be empty without any header, which will cause the downstream error by samtools: `[main_samview] fail to read the header from "-"`. To avoid such error, a header will be printed for empty input bam files.